### PR TITLE
Make "Code-Review+1" blue when highlighted

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# OctoGerrit
+# OctoGerrit - Tomologic Edition
 
 A modern, clean, and usable theme for Gerrit modeled after Github.
 
-This is a **WORK IN PROGRESS**
+**This is a fork of https://github.com/shellscape/OctoGerrit with 
+specific changes that suites Tomologic better. General improvement are
+pull requested upstream**
 
 [Using OctoGerrit](USING.md)  
 [Contributing to OctoGerrit](CONTRIBUTING.md)

--- a/dist/octogerrit.css
+++ b/dist/octogerrit.css
@@ -107,9 +107,6 @@ table.screenHeader {
 .com-google-gerrit-client-change-ChangeScreen_BinderImpl_GenCss_style-projectSettings img {
   display: none;
 }
-.com-google-gerrit-client-change-ChangeScreen_BinderImpl_GenCss_style-pushCertStatus {
-  display: none;
-}
 div.gerrit-size {
   white-space: nowrap;
 }
@@ -418,9 +415,6 @@ table.changeTable tbody tr:first-child td.dataHeader:nth-child(4) {
 .accountDashboard tbody tr:first-child td.dataHeader:nth-child(6) {
   width: 124px;
 }
-.accountDashboard tbody tr:first-child td.dataHeader:nth-child(4) {
-  display: none;
-}
 td.sectionHeader,
 table.changeTable.accountDashboard td.sectionHeader:last-child {
   background: #fff !important;
@@ -463,15 +457,6 @@ td.dataCell:nth-child(7) a {
   text-overflow: ellipsis;
   white-space: nowrap;
   width: 94px;
-}
-td.dataCell:nth-child(8),
-td.dataHeader:nth-child(8) {
-  /* branch cell */
-  display: none;
-}
-td.iconCell,
-td.iconHeader {
-  display: none;
 }
 td.cAPPROVAL:nth-child(12) div.gerrit-state-minus-two:before {
   content: '\f126';
@@ -955,9 +940,6 @@ div.com-google-gerrit-client-diff-CommentBox-Style-commentBox {
   overflow: hidden;
   position: relative;
 }
-div.com-google-gerrit-client-diff-CommentBox-Style-commentBox img.com-google-gerrit-client-diff-PublishedBox_BinderImpl_GenCss_style-avatar {
-  display: none;
-}
 div.com-google-gerrit-client-diff-CommentBox-Style-commentBox button div {
   color: #333 !important;
   font-weight: bold !important;
@@ -984,7 +966,6 @@ div.com-google-gerrit-client-diff-CommentBox-Style-message {
   padding: 10px;
 }
 div.com-google-gerrit-client-diff-CommentBox-Style-contents {
-  margin: 0;
   padding: 0;
   /* the buttons containing element */
 }

--- a/dist/octogerrit.css
+++ b/dist/octogerrit.css
@@ -668,8 +668,11 @@ div.com-google-gerrit-client-change-ChangeScreen_BinderImpl_GenCss_style-idAndSt
 table.com-google-gerrit-client-change-FileTable-FileTableCss-table {
   width: 100%;
 }
+button.com-google-gerrit-client-change-ChangeScreen_BinderImpl_GenCss_style-highlight {
+  background-image: -webkit-linear-gradient(top, #4d90fe, #4d90fe);
+}
 button.com-google-gerrit-client-change-ChangeScreen_BinderImpl_GenCss_style-highlight div {
-  color: #333 !important;
+  color: #fff !important;
 }
 span.com-google-gerrit-client-change-ChangeScreen_BinderImpl_GenCss_style-label_user {
   font-size: 12px;

--- a/dist/theme/GerritSite.css
+++ b/dist/theme/GerritSite.css
@@ -107,9 +107,6 @@ table.screenHeader {
 .com-google-gerrit-client-change-ChangeScreen_BinderImpl_GenCss_style-projectSettings img {
   display: none;
 }
-.com-google-gerrit-client-change-ChangeScreen_BinderImpl_GenCss_style-pushCertStatus {
-  display: none;
-}
 div.gerrit-size {
   white-space: nowrap;
 }
@@ -418,9 +415,6 @@ table.changeTable tbody tr:first-child td.dataHeader:nth-child(4) {
 .accountDashboard tbody tr:first-child td.dataHeader:nth-child(6) {
   width: 124px;
 }
-.accountDashboard tbody tr:first-child td.dataHeader:nth-child(4) {
-  display: none;
-}
 td.sectionHeader,
 table.changeTable.accountDashboard td.sectionHeader:last-child {
   background: #fff !important;
@@ -463,15 +457,6 @@ td.dataCell:nth-child(7) a {
   text-overflow: ellipsis;
   white-space: nowrap;
   width: 94px;
-}
-td.dataCell:nth-child(8),
-td.dataHeader:nth-child(8) {
-  /* branch cell */
-  display: none;
-}
-td.iconCell,
-td.iconHeader {
-  display: none;
 }
 td.cAPPROVAL:nth-child(12) div.gerrit-state-minus-two:before {
   content: '\f126';
@@ -955,9 +940,6 @@ div.com-google-gerrit-client-diff-CommentBox-Style-commentBox {
   overflow: hidden;
   position: relative;
 }
-div.com-google-gerrit-client-diff-CommentBox-Style-commentBox img.com-google-gerrit-client-diff-PublishedBox_BinderImpl_GenCss_style-avatar {
-  display: none;
-}
 div.com-google-gerrit-client-diff-CommentBox-Style-commentBox button div {
   color: #333 !important;
   font-weight: bold !important;
@@ -984,7 +966,6 @@ div.com-google-gerrit-client-diff-CommentBox-Style-message {
   padding: 10px;
 }
 div.com-google-gerrit-client-diff-CommentBox-Style-contents {
-  margin: 0;
   padding: 0;
   /* the buttons containing element */
 }

--- a/dist/theme/GerritSite.css
+++ b/dist/theme/GerritSite.css
@@ -668,8 +668,11 @@ div.com-google-gerrit-client-change-ChangeScreen_BinderImpl_GenCss_style-idAndSt
 table.com-google-gerrit-client-change-FileTable-FileTableCss-table {
   width: 100%;
 }
+button.com-google-gerrit-client-change-ChangeScreen_BinderImpl_GenCss_style-highlight {
+  background-image: -webkit-linear-gradient(top, #4d90fe, #4d90fe);
+}
 button.com-google-gerrit-client-change-ChangeScreen_BinderImpl_GenCss_style-highlight div {
-  color: #333 !important;
+  color: #fff !important;
 }
 span.com-google-gerrit-client-change-ChangeScreen_BinderImpl_GenCss_style-label_user {
   font-size: 12px;

--- a/dist/theme/GerritSiteFooter.html
+++ b/dist/theme/GerritSiteFooter.html
@@ -1,1 +1,1 @@
-<script src="//https://cdn.rawgit.com/shellscape/OctoGerrit/v1.0.2/dist/octogerrit.js"></script>
+<script src="//cdn.rawgit.com/shellscape/OctoGerrit/v1.0.2/dist/octogerrit.js"></script>

--- a/dist/theme/GerritSiteFooter.html
+++ b/dist/theme/GerritSiteFooter.html
@@ -1,1 +1,1 @@
-<script src="//cdn.rawgit.com/shellscape/OctoGerrit/v1.0.2/dist/octogerrit.js"></script>
+<script src="//https://cdn.rawgit.com/shellscape/OctoGerrit/v1.0.2/dist/octogerrit.js"></script>

--- a/src/html/GerritSiteFooter.html
+++ b/src/html/GerritSiteFooter.html
@@ -1,1 +1,1 @@
-<script src="//https://cdn.rawgit.com/shellscape/OctoGerrit/v{{version}}/dist/octogerrit.js"></script>
+<script src="//cdn.rawgit.com/shellscape/OctoGerrit/v{{version}}/dist/octogerrit.js"></script>

--- a/src/less/base.less
+++ b/src/less/base.less
@@ -72,10 +72,6 @@ table.screenHeader {
   }
 }
 
-.@{change}-pushCertStatus {
-  display: none;
-}
-
 div.gerrit-size {
 	white-space: nowrap;
 

--- a/src/less/diff-sidebyside.less
+++ b/src/less/diff-sidebyside.less
@@ -223,10 +223,6 @@ div.@{diffComment}-commentBox {
   overflow: hidden;
   position: relative;
 
-  img.@{diffPublished}-avatar {
-    display: none;
-  }
-
   button div {
   	color: #333 !important;
     font-weight: bold !important;
@@ -260,7 +256,6 @@ div.@{diffComment}-message {
 }
 
 div.@{diffComment}-contents {
-  margin: 0;
   padding: 0;
 
   * {

--- a/src/less/review.less
+++ b/src/less/review.less
@@ -192,8 +192,12 @@ table.@{fileTable}-table {
   width: 100%;
 }
 
+button.@{change}-highlight {
+  background-image: -webkit-linear-gradient(top, #4d90fe, #4d90fe);
+}
+
 button.@{change}-highlight div {
-  color: #333 !important;
+  color: #fff !important;
 }
 
 span.@{change}-label_user {

--- a/src/less/tables.less
+++ b/src/less/tables.less
@@ -145,9 +145,6 @@ table.changeTable {
         width: 124px;
       }
 
-      &:nth-child(4) {
-      	display: none;
-      }
     }
   }
 }
@@ -199,17 +196,6 @@ td.dataCell:nth-child(7) a {
   text-overflow: ellipsis;
   white-space: nowrap;
   width: 94px;
-}
-
-td.dataCell:nth-child(8),
-td.dataHeader:nth-child(8) {
-  /* branch cell */
-  display: none;
-}
-
-td.iconCell,
-td.iconHeader {
-  display: none;
 }
 
 td.cAPPROVAL:nth-child(12) {


### PR DESCRIPTION
The action most likely to be the next to do is highlighted in Gerrit with a blue background.

Before: 
![before](https://cloud.githubusercontent.com/assets/3041463/19112498/634a381a-8b05-11e6-8dbf-27d3904ef83a.png)

After:
![after](https://cloud.githubusercontent.com/assets/3041463/19112497/63493f28-8b05-11e6-95a2-6ced9be4f655.png)
